### PR TITLE
MAINT: Ignore `PyCharm` project files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE
+.idea/


### PR DESCRIPTION
Ignore `PyCharm` project files in git: add the corresponding entry to `.gitignore`.