### PR TITLE
ENH: Add additional analyses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # bibbias
-Analyze a bib file for biases
+Analyze a bib file for biases.
+
+This tool allows to compute:
+- The gender diversity in first/last authors on a given BibTeX file.
+- The number of distinct first/last authors on a given BibTeX file.
+- The number of authors on a given BibTeX file.
+- The gender diversity of the authors on a given BibTeX file.
+- The number of instances the authors on a given BibTeX file are cited on another (e.g.
+  references) BibTeX file.
+
+The script can be called as:
+```
+bias.py \
+  manuscript_references.bib \
+  manuscript_bibfile.bib \
+  output_dirname/
+```

--- a/src/bias.py
+++ b/src/bias.py
@@ -21,15 +21,15 @@
 #
 #     https://www.nipreps.org/community/licensing/
 #
-import argparse
+
 import os
 import json
-import re
-from pathlib import Path
-from itertools import product
-
+import argparse
 import requests
-
+import re
+from collections import Counter
+from itertools import chain, product
+from pathlib import Path
 
 import pandas as pd
 
@@ -39,111 +39,207 @@ BIBBIAS_CACHE_PATH = Path(
 )
 BIBBIAS_CACHE_PATH.mkdir(exist_ok=True, parents=True)
 
+MALE = "M"
+FEMALE = "F"
+UNKNOWN = "None"
+
 BIB_KEY = "bib_key"
 FA_NAME = "fa_name"
-FA_SEX = "fa_sex"
+FA_GENDER = "fa_gender"
 LA_NAME = "la_name"
-LA_SEX = "la_sex"
+LA_GENDER = "la_gender"
 NAME = "name"
 
 FF = "FF"
 FM = "FM"
 MM = "MM"
 MF = "MF"
-CATEGORY = "Category"
-RATIO = "Ratio"
+RATIO = "ratio"
+
+SUM = "sum"
+MEDIAN = "median"
+NONZERO = "nonzero"
+
+MISSED = "missed"
+RESOLVED = "resolved"
+REFERENCES = "references"
+STATS = "stats"
+
+AUTHORS = "authors"
+COUNT = "count"
+GENDER = "gender"
+FIRST_LAST = "first_last"
+FIRST_AUTHOR = "first_author"
+LAST_AUTHOR = "last_author"
+RELEVANT_AUTHOR = "relevant_author"
+REFS_REPEATS = "refs_repeats"
+
+TSV = "tsv"
+FNAME_SEP = "."
+LABEL_SEP = "_"
 
 
-def _parser():
-    parser = argparse.ArgumentParser(
-        description="Run gender analytics on an existing BibTeX file",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument("bib_file", type=Path, help="The input bibtex file")
-    parser.add_argument("missed_query_file", type=Path, help="The missed query data file")
-    parser.add_argument("resolved_query_file", type=Path, help="The resolved query data file")
-    parser.add_argument("gender_report_file", type=Path, help="The gender report data file")
-    parser.add_argument("stats_report_file", type=Path, help="The stats report data file")
-    return parser
+def compose_filename(dirname, labels, extension):
+
+    file_rootname = "".join([label + LABEL_SEP for label in labels])[:-1]
+    file_basename = file_rootname + FNAME_SEP + extension
+    return dirname / file_basename
 
 
-def main(argv=None):
-    """Execute querying."""
+def get_cached_gender_mapping() -> dict:
+    """Get cached (first) name to gender mapping.
 
-    pargs = _parser().parse_args(argv)
-    # Read bib file
-    # to minimize bibtex -o minimized.bib texfile.aux
-    bibstr = pargs.bib_file.read_text()
+    Returns
+    -------
+    cached : :obj:`dict`
+        Cached (first) name to gender mapping.
+    """
 
-    # first pass
-    resolved, missed = find_gender(bibstr)
+    cached = {}
+    if (BIBBIAS_CACHE_PATH / "names.cache").exists():
+        cached = json.loads((BIBBIAS_CACHE_PATH / "names.cache").read_text())
 
-    if missed:
-        resolved, missed = find_gender(bibstr, query_names(missed))
-
-    gender_report = report_gender(resolved)
-    print(gender_report)
-
-    # Save data
-    sep = "\t"
-    index = False
-    na_rep = "NA"
-
-    # Missed and resolved query data
-    df_missed = pd.DataFrame(list(missed), columns=[NAME])
-    df_missed.to_csv(pargs.missed_query_file, sep=sep, index=index, na_rep=na_rep)
-
-    df_resolved = create_author_gender_df(resolved)
-    df_resolved.to_csv(pargs.resolved_query_file, sep=sep, index=index, na_rep=na_rep)
-
-    # Gender report
-    df_gender = pd.DataFrame([gender_report])
-    df_gender.to_csv(pargs.gender_report_file, sep=sep, index=index)
-
-    # Compute stats
-    df = compute_gender_stats(df_gender)
-    df.to_csv(pargs.stats_report_file, sep=sep, index=index, na_rep=na_rep)
+    return cached
 
 
-def find_gender(bibstr, cached=None):
-    """Find the gender for a given bib file."""
+def split_authors(authors: str) -> list:
+    """Split a string of authors into the individual authors.
+
+    Assumes individual authors are joined with ``and``.
+
+    Parameters
+    ----------
+    authors : :obj:`str`
+        Author list string.
+
+    Returns
+    -------
+    :obj:`list`
+        Author list.
+    """
+
+    return authors.split(" and")
+
+
+def get_authors(authors: str) -> list:
+    """Get authors from a string.
+
+    Parameters
+    ----------
+    authors : :obj:`str`
+        Author list string.
+
+    Returns
+    -------
+    :obj:`list`
+        Author list.
+    """
+
+    return list(map(lambda x: x.strip(), split_authors(authors)))
+
+
+def get_bib_authors(bibstr: str) -> dict:
+    """Get the author list for the given BibTeX file string.
+
+    Parameters
+    ----------
+    bibstr : :obj:`str`
+        BibTeX file string.
+
+    Returns
+    -------
+    :obj:`dict`
+        Author list for each BibTeX key.
+    """
 
     matches = re.findall(r"author\s=\s+\{(.*?)\}", bibstr, re.DOTALL)
     author_lists = [m.replace("\n", " ") for m in matches]
     bib_id = re.findall(r"@\w+\{(.*?),", bibstr)
+
+    return dict(sorted(zip(bib_id, author_lists)))
+
+
+def count_position_instances(authors: list, pos: tuple = (0, -1)) -> tuple[Counter, Counter]:
+    """Count the number of instances an author is at a given position.
+
+    Parameters
+    ----------
+    authors : :obj:`list`
+        Author list.
+    pos : :obj:`tuple`, optional
+        Positions where the instances are to be counted.
+
+    Returns
+    -------
+    :obj:`tuple`
+        Name to number of instance mapping.
+    """
+
+    return tuple(Counter(name[i] for name in authors) for i in pos)
+
+
+def extract_first_last_authors(bibstr: str) -> list:
+    """Extract first and last author names from a BibTeX file string.
+
+    Parameters
+    ----------
+    bibstr : :obj:`str`
+        BibTeX file string.
+
+    Returns
+    -------
+    first_last : :obj:`list`
+        First and last author name tuples.
+    """
+
+    authors = get_bib_authors(bibstr)
+
+    first_last = []
+    for _authors in authors.values():
+        _auth = get_authors(_authors)
+        first_last.append((_auth[0], _auth[-1]))
+
+    return first_last
+
+
+def get_first_name(authors: str) -> list:
+    """Get first names from the given author list.
+
+    Initials are removed from the author name.
+
+    Parameters
+    ----------
+    authors : :obj:`str`
+        Author list.
+
+    Returns
+    -------
+    :obj:`list`
+        Author first names.
+    """
+
     strip_initial = re.compile(r"\s*\w\.\s*")
 
-    if cached is None and (BIBBIAS_CACHE_PATH / "names.cache").exists():
-        cached = json.loads((BIBBIAS_CACHE_PATH / "names.cache").read_text())
-
-    cached = cached or {}
-
-    data = {}
-    missed = set()
-    for bid, authors in zip(bib_id, author_lists):
-        authlst = authors.split(" and")
-        first = strip_initial.sub("", authlst[0].strip().split(",")[-1].strip().lower())
-        last = strip_initial.sub("", authlst[-1].strip().split(",")[-1].strip().lower())
-        data[bid] = (
-            (first, cached.get(first, None)),
-            (last, cached.get(last, None)),
-        )
-
-        for f, n in data[bid]:
-            if n is None:
-                missed.add(f)
-
-    return data, missed
+    _authors = split_authors(authors)
+    return [strip_initial.sub("", auth.strip().split(",")[-1].strip().lower()) for auth in _authors]
 
 
-def query_names(nameset):
-    """Lookup names in local cache, if not found hit Gender API."""
+def query_names(nameset: set) -> dict:
+    """Lookup names in local cache, if not found hit Gender API.
 
-    cached = (
-        json.loads((BIBBIAS_CACHE_PATH / "names.cache").read_text())
-        if (BIBBIAS_CACHE_PATH / "names.cache").exists()
-        else {}
-    )
+    Parameters
+    ----------
+    nameset : :obj:`set`
+        (First) Names.
+
+    Returns
+    -------
+    cached : :obj:`dict`
+        (First) Name to gender mapping.
+    """
+
+    cached = get_cached_gender_mapping()
+
     misses = sorted(set(nameset) - set(cached.keys()))
 
     if not misses:
@@ -164,7 +260,7 @@ def query_names(nameset):
         if q.ok:
             responses[n] = q.json()
             if int(responses[n]["accuracy"]) >= 60:
-                cached[n] = "F" if responses[n]["gender"] == "female" else "M"
+                cached[n] = FEMALE if responses[n]["gender"] == "female" else MALE
 
     # Store cache
     (BIBBIAS_CACHE_PATH / "names.cache").write_text(json.dumps(cached, indent=2))
@@ -173,17 +269,305 @@ def query_names(nameset):
     return cached
 
 
-def report_gender(data):
-    """Generate a dictionary reporting gender of first and last authors."""
+def find_author_gender(bibstr: str, cached: dict | None = None) -> tuple[dict, dict]:
+    """Find the gender for the authors in the given BibTeX file string.
 
-    retval = {"".join(c): 0 for c in product(("M", "F", "None"), repeat=2)}
+    Parameters
+    ----------
+    bibstr : :obj:`str`
+        BibTeX file string.
+    cached : :obj:`dict`, optional
+        (First) Name to gender mapping.
+
+    Returns
+    -------
+    data : :obj:`dict`
+        Dictionary of ((first) name, gender) tuples for the authors for each
+        citation key.
+    missed : :obj:`dict`
+        Mapping of (first) names whose gender could not be determined to their
+        number of instances.
+    """
+
+    authors = get_bib_authors(bibstr)
+
+    cached = cached or get_cached_gender_mapping()
+
+    data = {}
+    missed = {}
+    for bib_id, _authors in authors.items():
+        first_names = get_first_name(_authors)
+        data[bib_id] = tuple((name, cached.get(name, None)) for name in first_names)
+
+        missed[bib_id] = {}
+        for f, n in data[bib_id]:
+            if n is None:
+                missed[bib_id][f] = missed.get(f, 0) + 1
+
+    return data, missed
+
+
+def compute_gender_totals(data: dict) -> dict:
+    """Compute the gender totals in the data.
+
+    Parameters
+    ----------
+    data : :obj:`dict`
+        Dictionary of ((first) name, gender) tuples for the authors for each
+        citation key.
+
+    Returns
+    -------
+    gender_distr : :obj:`dict`
+        Gender totals for each citation key.
+    """
+
+    gender_distr = {bib_id: {"".join(c): 0 for c in (MALE, FEMALE, UNKNOWN)} for bib_id in data}
+    for bib_id, author_gender in data.items():
+        list(map(lambda auth: gender_distr[bib_id].__setitem__(f"{auth[1]}", gender_distr[bib_id][f"{auth[1]}"] + 1),  author_gender))
+
+    return gender_distr
+
+
+def find_first_last_gender(bibstr: str, cached: dict | None = None) -> tuple[dict, dict]:
+    """Find the gender for the first and last authors in the given BibTeX file string.
+
+    Parameters
+    ----------
+    bibstr : :obj:`str`
+        BibTeX file string.
+    cached : :obj:`dict`, optional
+        (First) Name to gender mapping.
+
+    Returns
+    -------
+    data : :obj:`dict`
+        Dictionary of ((first) name, gender) tuple pairs for the first and last
+        author for each citation key.
+    missed : :obj:`dict`
+        Mapping of (first) names whose gender could not be determined to their
+        number of instances.
+    """
+
+    authors = get_bib_authors(bibstr)
+
+    cached = cached or get_cached_gender_mapping()
+
+    data = {}
+    missed = {}
+    for bib_id, _authors in authors.items():
+        first_auth_name, last_auth_name = (first_names := get_first_name(_authors))[0], first_names[-1]
+        data[bib_id] = (
+            (first_auth_name, cached.get(first_auth_name, None)),
+            (last_auth_name, cached.get(last_auth_name, None)),
+        )
+
+        for f, n in data[bib_id]:
+            if n is None:
+                missed[f] = missed.get(f, 0) + 1
+
+    return data, missed
+
+
+def get_author_gender_distribution(bibstr: str) -> tuple[dict, dict]:
+    """Get the author gender distribution from a BibTeX file string.
+
+    Parameters
+    ----------
+    bibstr : :obj:`str`
+        BibTeX file string.
+
+    Returns
+    -------
+    resolved : :obj:`dict`
+        Dictionary of ((first) name, gender) tuples for the authors for each
+        citation key.
+    missed : :obj:`dict`
+        Mapping of (first) names whose gender could not be determined to their
+        number of instances.
+    """
+
+    # first pass
+    resolved, missed = find_author_gender(bibstr)
+
+    if missed:
+        resolved, missed = find_author_gender(bibstr, query_names(missed))
+
+    return resolved, missed
+
+
+def get_first_last_gender_distribution(bibstr: str) -> tuple[dict, dict]:
+    """Get the first and last author gender distribution from a BibTeX file string.
+
+    Parameters
+    ----------
+    bibstr : :obj:`str`
+        BibTeX file string.
+
+    Returns
+    -------
+    resolved : :obj:`dict`
+        Dictionary of ((first) name, gender) tuple pairs for the first and last
+        author for each citation key.
+    missed : :obj:`dict`
+        Mapping of (first) names whose gender could not be determined to their
+        number of instances.
+    """
+
+    # first pass
+    resolved, missed = find_first_last_gender(bibstr)
+
+    if missed:
+        resolved, missed = find_first_last_gender(bibstr, query_names(missed))
+
+    return resolved, missed
+
+
+def compute_first_last_gender_totals(data: dict) -> dict:
+    """Compute the (first, last) author gender pair totals in the data.
+
+    Parameters
+    ----------
+    data : :obj:`dict`
+        Dictionary of ((first) name, gender) tuple pairs for the first and last
+        author for each citation key.
+
+    Returns
+    -------
+    gender_distr : :obj:`dict`
+        Dictionary of {gender: count} items where the gender contains the
+        products for the ("M", "F", "None") strings (the first element denoting
+        the gender of the first author, the second denoting the gender for the
+        last), and the count contains the number of times of the event.
+    """
+
+    gender_distr = {"".join(c): 0 for c in product((MALE, FEMALE, UNKNOWN), repeat=2)}
     for first, last in data.values():
-        retval[f"{first[1]}{last[1]}"] += 1
+        gender_distr[f"{first[1]}{last[1]}"] += 1
 
-    return retval
+    return gender_distr
 
 
-def create_author_gender_df(author_gender_data):
+def count_author_reference_instances(author_bibstr: str, refs_bibstr: str) -> dict:
+    """Count the number of instances an author is referenced.
+
+    Counts the number of instances an author from the ``author_bibstr`` BibTeX
+    string appears as an author in the ``refs_bibstr`` BibTeX string.
+
+    Parameters
+    ----------
+    author_bibstr : :obj:`str`
+        Autor BibTeX file string.
+    refs_bibstr : :obj:`str`
+        References BibTeX file string.
+
+    Returns
+    -------
+    common_auth_count : :obj:`dict`
+        Number of instances an author is referenced.
+    """
+
+    authors = get_bib_authors(author_bibstr)
+    ref_authors = get_bib_authors(refs_bibstr)
+
+    # Flatten the values in references and count occurrences of each author
+    _ref_authors = sorted(chain.from_iterable([split_authors(names) for names in ref_authors.values()]))
+    # Remove leading and trailing whitespaces
+    _ref_authors = sorted([item.strip() for item in _ref_authors])
+
+    common_auth = {}
+    common_auth_count = {}
+    for bib_id, _authors in authors.items():
+        _auth = get_authors(_authors)
+        # Find common authors
+        common_auth[bib_id] = sorted(set(_auth) & set(_ref_authors))
+        # Number of times each author appears
+        ref_counts = Counter(name for name in _ref_authors)
+        common_auth_count[bib_id] = {author: ref_counts[author] for author in common_auth[bib_id]}
+
+    return common_auth_count
+
+
+def count_first_last_instances(bibstr: str) -> tuple[dict, dict, list]:
+    """Count the number of instances an author is first or last in a BibTeX file
+    string.
+
+    Parameters
+    ----------
+    bibstr : :obj:`str`
+        BibTeX file string.
+
+    Returns
+    -------
+    first_auth_count : :obj:`dict`
+        Name to first author instance count mapping.
+    self_last_author_counts : :obj:`dict`
+        Name to last author instance count mapping.
+    first_last_auth : :obj:`list`
+        First and last author name tuples.
+    """
+
+    first_last = extract_first_last_authors(bibstr)
+
+    _first_auth_count, _last_auth_count = count_position_instances(first_last, pos=(0, -1))
+
+    first_auth_count = dict(sorted(_first_auth_count.items()))
+    last_auth_count = dict(sorted(_last_auth_count.items()))
+
+    return first_auth_count, last_auth_count, first_last
+
+
+def count_self_first_last_instances(author_bibstr: str, refs_bibstr: str) -> tuple[dict, dict]:
+    """Count the number of instances an author is first or last author.
+
+    Counts the number of instances an author from the ``author_bibstr`` BibTeX
+    string appears as a first or last author in the ``refs_bibstr`` BibTeX
+    string.
+
+    Parameters
+    ----------
+    author_bibstr : :obj:`str`
+        Autor BibTeX file string.
+    refs_bibstr : :obj:`str`
+        References BibTeX file string.
+
+    Returns
+    -------
+    self_first_auth_count : :obj:`dict`
+        Name to first author instance count mapping for each BibTeX key.
+    self_last_auth_count : :obj:`dict`
+        Name to last author instance count mapping for each BibTeX key.
+    """
+
+    authors = get_bib_authors(author_bibstr)
+    ref_first_last_authors = extract_first_last_authors(refs_bibstr)
+
+    _ref_first_auth_count, _ref_last_auth_count = count_position_instances(ref_first_last_authors, pos=(0, -1))
+
+    self_first_auth_count = {}
+    self_last_auth_count = {}
+    for bib_id, _authors in authors.items():
+        _auth = get_authors(_authors)
+        self_first_auth_count[bib_id] = {author: _ref_first_auth_count[author] for author in _auth}
+        self_last_auth_count[bib_id] = {author: _ref_last_auth_count[author] for author in _auth}
+
+    return self_first_auth_count, self_last_auth_count
+
+
+def create_first_last_author_gender_df(author_gender_data: dict) -> pd.DataFrame:
+    """Create a fist/last author gender dataframe.
+
+    Parameters
+    ----------
+    author_gender_data : :obj:`dict`
+        Dictionary of ((first) name, gender) tuple pairs for the first and last
+        author for each citation key.
+
+    Returns
+    -------
+    :obj:`pd.DataFrame`
+        First/last author gender.
+    """
 
     # Prepare lists to hold the data for the DataFrame
     keys = []
@@ -207,22 +591,316 @@ def create_author_gender_df(author_gender_data):
 
     # Create a DataFrame
     return pd.DataFrame({
-        "BIB_KEY": keys,
-        "FA_NAME": fa_names,
-        "FA_GENDER": fa_gender,
-        "LA_NAME": la_names,
-        "LA_GENDER": la_gender,
+        BIB_KEY: keys,
+        FA_NAME: fa_names,
+        FA_GENDER: fa_gender,
+        LA_NAME: la_names,
+        LA_GENDER: la_gender,
     })
 
 
-def compute_gender_stats(df):
-    total = df.sum(axis=1).iloc[0]
-    ratios = df.iloc[0] / total
+def compute_first_last_gender(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute counts on first/last author gender.
 
-    ratios_df = pd.DataFrame(ratios).reset_index()
-    ratios_df.columns = [CATEGORY, RATIO]
+    Parameters
+    ----------
+    df : :obj:`pd.DataFrame`
+        Gender data.
+
+    Returns
+    -------
+    df_fa_la_gender_count : :obj:`pd.DataFrame`
+        First/last author gender counts.
+    """
+
+    # Define possible categories
+    categories = [MALE, FEMALE, UNKNOWN]
+
+    # Parse first and second by checking against known categories
+    def _parse_pair(pair):
+        for cat in categories:
+            if pair.startswith(cat):
+                first = cat
+                second = pair[len(cat):]
+                return first, second
+        return None, None  # fallback, shouldn't happen
+
+    _df = df.copy()
+    _df[[FIRST_AUTHOR, LAST_AUTHOR]] = _df[GENDER].apply(
+        lambda x: pd.Series(_parse_pair(x)))
+
+    # Group and sum
+    fa_gender_count = _df.groupby(FIRST_AUTHOR)[COUNT].sum()
+    la_gender_count = _df.groupby(LAST_AUTHOR)[COUNT].sum()
+
+    df_fa_la_gender_count = pd.DataFrame({
+        GENDER: fa_gender_count.keys(),
+        FIRST_AUTHOR: fa_gender_count,
+        LAST_AUTHOR: la_gender_count
+    }).reset_index(drop=True)
+
+    return df_fa_la_gender_count
+
+
+def compute_gender_ratio(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute gender ratio.
+
+    Parameters
+    ----------
+    df : :obj:`pd.DataFrame`
+        Gender data.
+
+    Returns
+    -------
+    :obj:`pd.DataFrame`
+        Gender ratio.
+    """
+
+    total = df[COUNT].sum()
+    ratios = df[COUNT] / total
+
+    ratios_df = pd.DataFrame([df[GENDER], ratios]).T
+    ratios_df.columns = [GENDER, RATIO]
 
     return ratios_df
+
+
+def compute_count_stats(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute count statistics.
+
+    Parameters
+    ----------
+    df : :obj:`pd.DataFrame`
+        Count data.
+
+    Returns
+    -------
+    :obj:`pd.DataFrame`
+        Count statistics.
+    """
+
+    desc = df.describe()
+    desc.loc[SUM] = df.sum(numeric_only=True)
+    desc.loc[MEDIAN] = df.median(numeric_only=True)
+    desc.loc[NONZERO] = df.astype(bool).sum(axis=0)
+
+    return desc
+
+
+def _parser():
+    parser = argparse.ArgumentParser(
+        description="Run author and citation diversity, equity and inclusiveness analytics on BibTeX files",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("author_bib_file", type=Path, help="Input author BibTeX file")
+    parser.add_argument("refs_bib_file", type=Path, help="Input references BibTeX file")
+    parser.add_argument("output_folder", type=Path, help="Output folder")
+
+    return parser
+
+
+def main(argv=None):
+    """Execute querying."""
+
+    pargs = _parser().parse_args(argv)
+    # Read bib files
+    # to minimize bibtex -o minimized.bib texfile.aux
+    author_bibstr = pargs.author_bib_file.read_text()
+    refs_bibstr = pargs.refs_bib_file.read_text()
+
+    resolved, missed = get_first_last_gender_distribution(refs_bibstr)
+    ref_gender_report = compute_first_last_gender_totals(resolved)
+
+    print("Gender diversity bias in references")
+    print(f"Number of references: {len(resolved.keys())}")
+    print("Resolved")
+    print(resolved)
+    print("Missed")
+    print(missed)
+    print(ref_gender_report)
+
+    first_auth_count, last_auth_count, first_last = count_first_last_instances(refs_bibstr)
+
+    print("\nFirst/last diversity bias in references")
+    print(f"First author repeats across refs: {first_auth_count}")
+    print(f"Last author repeats across refs: {last_auth_count}")
+    print(f"Number of different firsts: {len(first_auth_count)/len(first_last)} ({len(first_auth_count)}/{len(first_last)})")
+    print(f"Number of different lasts: {len(last_auth_count)/len(first_last)} ({len(last_auth_count)}/{len(first_last)})")
+
+    _resolved, _missed = get_author_gender_distribution(author_bibstr)
+    auth_gender_report = compute_gender_totals(_resolved)
+
+    print("\nAuthor gender bias")
+    print(f"Number of authors: {len(list(_resolved.values())[0])}")
+    print("Resolved")
+    print(_resolved)
+    print("Missed")
+    print(_missed)
+    print(auth_gender_report)
+
+    print("\nAuthor reference bias")
+
+    common_auth_count = count_author_reference_instances(author_bibstr, refs_bibstr)
+    self_first_auth_count, self_last_auth_count = count_self_first_last_instances(author_bibstr, refs_bibstr)
+
+    print("Authors that also appear in references")
+    print(common_auth_count)
+
+    print("Self first/last instances")
+    print("Self authors as first authors in refs")
+    print(self_first_auth_count)
+    print("Self authors as last authors in refs")
+    print(self_last_auth_count)
+
+    # Save data
+    sep = "\t"
+    report_index = False
+    stats_index = True
+    ratio_index = False
+    na_rep = "NA"
+
+    # Refs gender diversity bias
+    labels = [REFERENCES, GENDER, MISSED]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_missed = pd.DataFrame(list(missed.items()), columns=[NAME, COUNT])
+    df_missed.to_csv(fname, sep=sep, index=report_index, na_rep=na_rep)
+
+    labels = [REFERENCES, GENDER, RESOLVED]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_resolved = create_first_last_author_gender_df(resolved)
+    df_resolved.to_csv(fname, sep=sep, index=report_index, na_rep=na_rep)
+
+    labels = [REFERENCES, FIRST_LAST, GENDER, COUNT]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_gender = pd.DataFrame(list(ref_gender_report.items()), columns=[GENDER, COUNT])
+    df_gender.to_csv(fname, sep=sep, index=report_index)
+
+    df_ratio = compute_gender_ratio(df_gender)
+
+    labels = [REFERENCES, FIRST_LAST, GENDER, RATIO]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_ratio.to_csv(fname, sep=sep, index=ratio_index, na_rep=na_rep)
+
+    df_fa_la_gender_count = compute_first_last_gender(df_gender)
+
+    labels = [REFERENCES, GENDER, FIRST_AUTHOR, LAST_AUTHOR, COUNT]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_fa_la_gender_count.to_csv(fname, sep=sep, index=report_index, na_rep=na_rep)
+
+    df_fa_gender_count = df_fa_la_gender_count[[GENDER, FIRST_AUTHOR]].rename(columns={FIRST_AUTHOR: COUNT})
+
+    df_fa_gender_ratio = compute_gender_ratio(df_fa_gender_count)
+
+    labels = [REFERENCES, GENDER, FIRST_AUTHOR, RATIO]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_fa_gender_ratio.to_csv(fname, sep=sep, index=ratio_index, na_rep=na_rep)
+
+    df_la_gender_count = df_fa_la_gender_count[[GENDER, LAST_AUTHOR]].rename(columns={LAST_AUTHOR: COUNT})
+
+    df_la_gender_ratio= compute_gender_ratio(df_la_gender_count)
+
+    labels = [REFERENCES, GENDER, LAST_AUTHOR, RATIO]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_la_gender_ratio.to_csv(fname, sep=sep, index=ratio_index, na_rep=na_rep)
+
+    df_relevant_gender_count = pd.DataFrame({
+        GENDER: df_fa_la_gender_count[GENDER],
+        COUNT: df_fa_la_gender_count[FIRST_AUTHOR] + df_fa_la_gender_count[LAST_AUTHOR]
+    })
+    labels = [REFERENCES, GENDER, RELEVANT_AUTHOR, COUNT]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_relevant_gender_count.to_csv(fname, sep=sep, index=report_index, na_rep=na_rep)
+
+    df_relevant_gender_ratio = compute_gender_ratio(df_relevant_gender_count)
+
+    labels = [REFERENCES, GENDER, RELEVANT_AUTHOR, RATIO]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_relevant_gender_ratio.to_csv(fname, sep=sep, index=ratio_index, na_rep=na_rep)
+
+    # Refs first/last count diversity bias
+    labels = [REFERENCES, FIRST_AUTHOR, COUNT]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_fa_count = pd.DataFrame(list(first_auth_count.items()), columns=[NAME, COUNT])
+    df_fa_count.to_csv(fname, sep=sep, index=report_index, na_rep=na_rep)
+
+    df_fa_stats = compute_count_stats(df_fa_count)
+
+    labels = [REFERENCES, FIRST_AUTHOR, STATS]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_fa_stats.to_csv(fname, sep=sep, index=stats_index)
+
+    labels = [REFERENCES, LAST_AUTHOR, COUNT]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_la_count = pd.DataFrame(list(last_auth_count.items()), columns=[NAME, COUNT])
+    df_la_count.to_csv(fname, sep=sep, index=report_index, na_rep=na_rep)
+
+    df_la_stats = compute_count_stats(df_la_count)
+
+    labels = [REFERENCES, LAST_AUTHOR, STATS]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_la_stats.to_csv(fname, sep=sep, index=stats_index)
+
+    labels = [REFERENCES, FIRST_LAST]
+    fname = compose_filename(pargs.output_folder, labels, TSV)
+    df_fl = pd.DataFrame(first_last, columns=[FIRST_AUTHOR, LAST_AUTHOR])
+    df_fl.to_csv(fname, sep=sep, index=report_index, na_rep=na_rep)
+
+    # Authors gender diversity bias
+    bib_id = list(auth_gender_report.keys())
+    for _id in bib_id:
+        labels = [AUTHORS, GENDER, MISSED, _id]
+        fname = compose_filename(pargs.output_folder, labels, TSV)
+        df_missed = pd.DataFrame(list(_missed[_id].items()), columns=[NAME, COUNT])
+        df_missed.to_csv(fname, sep=sep, index=report_index, na_rep=na_rep)
+
+        labels = [AUTHORS, GENDER, RESOLVED, _id]
+        fname = compose_filename(pargs.output_folder, labels, TSV)
+        df_resolved = pd.DataFrame(_resolved[_id], columns=[NAME, COUNT])
+        df_resolved.to_csv(fname, sep=sep, index=report_index, na_rep=na_rep)
+
+        labels = [AUTHORS, GENDER, _id]
+        fname = compose_filename(pargs.output_folder, labels, TSV)
+        df_gender = pd.DataFrame(list(auth_gender_report[_id].items()), columns=[GENDER, COUNT])
+        df_gender.to_csv(fname, sep=sep, index=report_index)
+
+        # Compute ratio
+        df_ratio = compute_gender_ratio(df_gender)
+
+        labels = [AUTHORS, GENDER, RATIO, _id]
+        fname = compose_filename(pargs.output_folder, labels, TSV)
+        df_ratio.to_csv(fname, sep=sep, index=ratio_index)
+
+    # Authors ref count diversity bias
+    for _id in bib_id:
+        labels = [AUTHORS, REFERENCES, COUNT, _id]
+        fname = compose_filename(pargs.output_folder, labels, TSV)
+        df_ref_count = pd.DataFrame(common_auth_count[_id].items(), columns=[NAME, COUNT])
+        df_ref_count.to_csv(fname, sep=sep, index=report_index)
+
+        df_ref_stats = compute_count_stats(df_ref_count)
+        labels = [AUTHORS, REFERENCES, STATS, _id]
+        fname = compose_filename(pargs.output_folder, labels, TSV)
+        df_ref_stats.to_csv(fname, sep=sep, index=stats_index)
+
+        labels = [AUTHORS, REFERENCES, FIRST_AUTHOR, COUNT, _id]
+        fname = compose_filename(pargs.output_folder, labels, TSV)
+        df_ref_fa_count = pd.DataFrame(self_first_auth_count[_id].items(), columns=[NAME, COUNT])
+        df_ref_fa_count.to_csv(fname, sep=sep, index=report_index)
+
+        df_ref_fa_stats = compute_count_stats(df_ref_fa_count)
+        labels = [AUTHORS, REFERENCES, FIRST_AUTHOR, STATS, _id]
+        fname = compose_filename(pargs.output_folder, labels, TSV)
+        df_ref_fa_stats.to_csv(fname, sep=sep, index=stats_index)
+
+        labels = [AUTHORS, REFERENCES, LAST_AUTHOR, COUNT, _id]
+        fname = compose_filename(pargs.output_folder, labels, TSV)
+        df_ref_la_count = pd.DataFrame(self_last_auth_count[_id].items(), columns=[NAME, COUNT])
+        df_ref_la_count.to_csv(fname, sep=sep, index=report_index)
+
+        df_ref_la_stats = compute_count_stats(df_ref_la_count)
+        labels = [AUTHORS, REFERENCES, LAST_AUTHOR, STATS, _id]
+        fname = compose_filename(pargs.output_folder, labels, TSV)
+        df_ref_la_stats.to_csv(fname, sep=sep, index=stats_index)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add additional analyses to provide a more comprehensive picture of the author and citation diversity, equity and inclusiveness:
- Report the number of instances a given author from the references citation file is listed as first/last.
- Report the number of different first/last authors.
- Report the gender distribution of an author citation file.
- Report the number of instances authors are cited in the references.
- Report the number of instances authors are cited as first/last in the references.
- Make the `missed` first names be a dictionary instead of a set in order to save the number of instances the missed first names were missed (i.e. how many times they are present in the relevant author list).
- Serialize the extracted features (gender, counts).

Refactor the script for an improved code encapsulation.

Given that the number of serialized features has increased, prefer specifying the output folder instead of requiring input filenames as program arguments.

Remove unused global variables.

Rename some global variables for the sake of consistency.

Sort functions in a more conventional way: make the parsing and `main` functions come last.

Sort the imported packages.

Document the functions.

Provide some minimal description in the `README` file of the features the tool is able to extract.